### PR TITLE
Add the 'from' static constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,21 @@ $result = (new PipeOperator('https://blog.github.com'))
 // blog
 ```
 
+You can also use the `from` static constructor:
+
+```php
+use Boost\PipeOperator\PipeOperator as Pipe;
+
+$result = Pipe::from('https://blog.github.com')
+    ->parse_url()
+    ->end()
+    ->explode('.', PIPED_VALUE)
+    ->reset()
+    ->get();
+
+// blog
+```
+
 ### Using closures
 
 You could also use closures for more flexibility:

--- a/src/PipeOperator.php
+++ b/src/PipeOperator.php
@@ -27,6 +27,17 @@ class PipeOperator
     }
 
     /**
+     * Create a new class instance.
+     *
+     * @param  mixed  $value
+     * @return self
+     */
+    public static function from($value): self
+    {
+        return new self($value);
+    }
+
+    /**
      * Dynamically call the piped function.
      *
      * @param  string  $name
@@ -54,7 +65,7 @@ class PipeOperator
      * @param  callable  $callback
      * @return $this
      */
-    public function pipe(callable $callback)
+    public function pipe(callable $callback): self
     {
         $this->value = $callback($this->value);
 

--- a/tests/PipeOperatorTest.php
+++ b/tests/PipeOperatorTest.php
@@ -30,4 +30,19 @@ class PipeOperatorTest extends TestCase
 
         $this->assertSame('tvguho.pbz', $result);
     }
+
+    /**
+     * @test
+     */
+    public function it_can_operate_on_values_passed_with_the_from_static_constructor()
+    {
+        $result = PipeOperator::from('https://blog.github.com')
+            ->parse_url()
+            ->end()
+            ->explode('.', PIPED_VALUE)
+            ->reset()
+            ->get();
+
+        $this->assertSame('blog', $result);
+    }
 }


### PR DESCRIPTION
This pull request adds the `from` static constructor, allowing the following syntax:

```php
use Boost\PipeOperator\PipeOperator as Pipe;

$result = Pipe::from('https://blog.github.com')
    ->parse_url()
    ->end()
    ->explode('.', PIPED_VALUE)
    ->reset()
    ->get();

// blog
```